### PR TITLE
Utvide håndtering av error for token exchange mot baksystemer

### DIFF
--- a/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/ExternalContentFecther.kt
+++ b/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/ExternalContentFecther.kt
@@ -11,7 +11,7 @@ import no.nav.tms.mikrofrontend.selector.collector.json.JsonPathInterpreter
 import no.nav.tms.mikrofrontend.selector.collector.json.JsonPathInterpreter.Companion.bodyAsNullOrJsonNode
 import no.nav.tms.token.support.tokenx.validation.user.TokenXUser
 import java.net.SocketTimeoutException
-import java.util.*
+import java.util.UUID
 import kotlin.reflect.full.primaryConstructor
 
 class ExternalContentFecther(

--- a/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/ExternalContentFecther.kt
+++ b/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/ExternalContentFecther.kt
@@ -184,7 +184,7 @@ class ExternalContentFecther(
     } catch (tokenFetcherException: TokenFetcher.TokenFetcherException){
         ResponseWithErrors.createWithError(
             constructor = T::class.primaryConstructor,
-            errorMessage = "error fetching token ${errorDetails(tokenFetcherException)}",
+            errorMessage = "error fetching token $tjeneste",
             className = T::class.qualifiedName ?: "unknown"
         )
     }

--- a/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/PersonalContentCollector.kt
+++ b/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/PersonalContentCollector.kt
@@ -80,7 +80,8 @@ class PersonalContentFactory(
             safResponse,
             meldekortResponse,
             oppfolgingResponse,
-            pdlResponse
+            pdlResponse,
+            digisosResponse
         ).mapNotNull { it.errorMessage() }.joinToString()
     }
 }

--- a/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/TokenFetcher.kt
+++ b/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/TokenFetcher.kt
@@ -18,6 +18,7 @@ class TokenFetcher(
         fetchWithErrorHandling("Oppfølging", oppfølgingClientId, user)
 
     suspend fun meldekortToken(user: TokenXUser): String = fetchWithErrorHandling("meldekort", meldekortClientId, user)
+
     suspend fun pdlToken(user: TokenXUser): String = fetchWithErrorHandling("pdl", pdlClientId, user)
 
     private suspend fun fetchWithErrorHandling(forService: String, appClientId: String, user: TokenXUser): String =

--- a/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/TokenFetcher.kt
+++ b/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/TokenFetcher.kt
@@ -28,7 +28,7 @@ class TokenFetcher(
             throw TokenFetcherException(e, forService, appClientId)
         }
 
-    suspend fun digisosToken(user: TokenXUser): String = fetchWithErrorHandling("digisos", digisosClientId, user)
+    suspend fun digisosToken(user: TokenXUser): String = fetchWithErrorHandling("digisos", "digisosClientId", user)
 
     class TokenFetcherException(originalException: Exception, forService: String, appClientId: String) :
         Exception("henting av token for $forService med clientId $appClientId feiler: ${errorDetails(originalException)}")

--- a/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/TokenFetcher.kt
+++ b/app/src/main/kotlin/no/nav/tms/mikrofrontend.selector/collector/TokenFetcher.kt
@@ -28,7 +28,7 @@ class TokenFetcher(
             throw TokenFetcherException(e, forService, appClientId)
         }
 
-    suspend fun digisosToken(user: TokenXUser): String = fetchWithErrorHandling("digisos", "digisosClientId", user)
+    suspend fun digisosToken(user: TokenXUser): String = fetchWithErrorHandling("digisos", digisosClientId, user)
 
     class TokenFetcherException(originalException: Exception, forService: String, appClientId: String) :
         Exception("henting av token for $forService med clientId $appClientId feiler: ${errorDetails(originalException)}")


### PR DESCRIPTION
Dersom tokenX mot en eller flere baksystem feiler, responder til klienten med data fra resterende baksystem og legg ved statuscode 207.  Dette for å unngå at feil ved fetch av token mot et baksystem skal spenne bein på resten av responsen. 